### PR TITLE
Rework values set in session on authorisation.

### DIFF
--- a/lib/simple_google_auth/receiver.rb
+++ b/lib/simple_google_auth/receiver.rb
@@ -8,7 +8,7 @@ module SimpleGoogleAuth
 
       ensure_params_are_correct(request, config)
       auth_data = obtain_authentication_data(request.params["code"], config)
-      id_data = decode_id_data(auth_data)
+      id_data = decode_id_data(auth_data.delete("id_token"))
 
       raise Error, "Authentication failed" unless config.authenticate.call(id_data)
 
@@ -66,8 +66,8 @@ module SimpleGoogleAuth
       JSON.parse(response.body)
     end
 
-    def decode_id_data(auth_data)
-      id_data_64 = auth_data.delete("id_token").split(".")[1]
+    def decode_id_data(id_data)
+      id_data_64 = id_data.split(".")[1]
       id_data_64 << "=" until id_data_64.length % 4 == 0
       JSON.parse(Base64.decode64(id_data_64))
     end


### PR DESCRIPTION
In order to use the auth details with other calls to google api's you
need access to the actual token, not just the hash. Instead of just
setting the details parsed out of the id_token value we set the
original auth hash merged with the hash that we parsed out of the id_token.
